### PR TITLE
写真のいいね機能

### DIFF
--- a/backend/src/api/like/content-types/like/schema.json
+++ b/backend/src/api/like/content-types/like/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "likes",
+  "info": {
+    "singularName": "like",
+    "pluralName": "likes",
+    "displayName": "like"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "photo": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::photo.photo",
+      "inversedBy": "likes"
+    },
+    "user": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "likes"
+    }
+  }
+}

--- a/backend/src/api/like/controllers/like.ts
+++ b/backend/src/api/like/controllers/like.ts
@@ -1,0 +1,7 @@
+/**
+ * like controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::like.like');

--- a/backend/src/api/like/routes/like.ts
+++ b/backend/src/api/like/routes/like.ts
@@ -1,0 +1,7 @@
+/**
+ * like router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::like.like');

--- a/backend/src/api/like/services/like.ts
+++ b/backend/src/api/like/services/like.ts
@@ -1,0 +1,7 @@
+/**
+ * like service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::like.like');

--- a/backend/src/api/photo/content-types/photo/schema.json
+++ b/backend/src/api/photo/content-types/photo/schema.json
@@ -38,6 +38,12 @@
       "relation": "manyToOne",
       "target": "api::category.category",
       "inversedBy": "photos"
+    },
+    "likes": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::like.like",
+      "mappedBy": "photo"
     }
   }
 }

--- a/backend/src/extensions/users-permissions/content-types/user/schema.json
+++ b/backend/src/extensions/users-permissions/content-types/user/schema.json
@@ -71,6 +71,12 @@
       "relation": "oneToMany",
       "target": "api::photo.photo",
       "mappedBy": "user"
+    },
+    "likes": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::like.like",
+      "mappedBy": "user"
     }
   }
 }

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -399,6 +399,36 @@ export interface ApiCategoryCategory extends Schema.CollectionType {
   };
 }
 
+export interface ApiLikeLike extends Schema.CollectionType {
+  collectionName: 'likes';
+  info: {
+    singularName: 'like';
+    pluralName: 'likes';
+    displayName: 'like';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    photo: Attribute.Relation<
+      'api::like.like',
+      'manyToOne',
+      'api::photo.photo'
+    >;
+    user: Attribute.Relation<
+      'api::like.like',
+      'manyToOne',
+      'plugin::users-permissions.user'
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::like.like', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<'api::like.like', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
 export interface ApiPhotoPhoto extends Schema.CollectionType {
   collectionName: 'photos';
   info: {
@@ -422,6 +452,11 @@ export interface ApiPhotoPhoto extends Schema.CollectionType {
       'api::photo.photo',
       'manyToOne',
       'api::category.category'
+    >;
+    likes: Attribute.Relation<
+      'api::photo.photo',
+      'oneToMany',
+      'api::like.like'
     >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
@@ -807,6 +842,11 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
       'oneToMany',
       'api::photo.photo'
     >;
+    likes: Attribute.Relation<
+      'plugin::users-permissions.user',
+      'oneToMany',
+      'api::like.like'
+    >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -882,6 +922,7 @@ declare module '@strapi/types' {
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'api::category.category': ApiCategoryCategory;
+      'api::like.like': ApiLikeLike;
       'api::photo.photo': ApiPhotoPhoto;
       'plugin::upload.file': PluginUploadFile;
       'plugin::upload.folder': PluginUploadFolder;

--- a/frontend/src/actions.ts
+++ b/frontend/src/actions.ts
@@ -12,5 +12,6 @@ export async function logoutAction() {
     secure: process.env.NODE_ENV === "production",
   };
   cookies().set("jwt", "", { ...config, maxAge: 0 });
+  cookies().set("user", "", { ...config, maxAge: 0 });
   redirect("/");
 }

--- a/frontend/src/app/(dynamic)/photos/[photoId]/page.tsx
+++ b/frontend/src/app/(dynamic)/photos/[photoId]/page.tsx
@@ -1,3 +1,4 @@
+import LikeButton from "@/components/LikeButton";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { getPhoto } from "@/lib/strapi";
 import { UserCircleIcon } from "lucide-react";
@@ -20,7 +21,10 @@ const PhotoPage: FC<Props> = async ({ params }) => {
 
   return (
     <div className="flex flex-col px-2 py-2">
-      <h2 className="text-lg font-bold">{photo?.data.attributes.title}</h2>
+      <div className="flex flex-row justify-between items-center h-10">
+        <h2 className="text-lg font-bold">{photo?.data.attributes.title}</h2>
+        <LikeButton photoId={Number(photo?.data.id)} />
+      </div>
       {photo?.data.attributes.image.data && (
         <Image
           src={`http://localhost:1337${photo?.data.attributes.image.data?.attributes.url}`}

--- a/frontend/src/app/api/connect/[provider]/redirect/route.ts
+++ b/frontend/src/app/api/connect/[provider]/redirect/route.ts
@@ -32,6 +32,7 @@ export async function GET(request: Request, params: { params: { provider: string
   const data = await res.json();
 
   cookies().set("jwt", data.jwt, config);
+  cookies().set("user", data.user.id, config);
 
   return NextResponse.redirect(new URL("/profile", request.url));
 }

--- a/frontend/src/app/api/likes/[id]/route.ts
+++ b/frontend/src/app/api/likes/[id]/route.ts
@@ -1,0 +1,22 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function DELETE(request: Request, params: { params: { id: string } }) {
+  const { id } = params.params;
+  const jwtToken = cookies().get("jwt");
+  const userToken = cookies().get("user");
+
+  if (!jwtToken || !userToken) {
+    return new Response(null, { status: 401 });
+  }
+
+  const response = await fetch(`http://localhost:1337/api/likes/${id}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${jwtToken.value}`,
+    },
+  });
+  const { data } = await response.json();
+  return NextResponse.json({ data: { id: data.id } }, { status: response.status });
+}

--- a/frontend/src/app/api/photos/[id]/likes/me/route.ts
+++ b/frontend/src/app/api/photos/[id]/likes/me/route.ts
@@ -1,0 +1,29 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request, params: { params: { id: string } }) {
+  const { id } = params.params;
+  const jwtToken = cookies().get("jwt");
+  const userToken = cookies().get("user");
+
+  if (!jwtToken || !userToken) {
+    return new Response(null, { status: 401 });
+  }
+
+  const response = await fetch(
+    `http://localhost:1337/api/likes?pagination[pageSize]=1&filters[photo][$eq]=${id}&filters[user][$eq]=${userToken.value}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken.value}`,
+      },
+    }
+  );
+  const { data } = await response.json();
+
+  return NextResponse.json(
+    { data: data.map((item: { id: number }) => ({ id: item.id })) },
+    { status: 200 }
+  );
+}

--- a/frontend/src/app/api/photos/[id]/likes/route.ts
+++ b/frontend/src/app/api/photos/[id]/likes/route.ts
@@ -1,0 +1,78 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+// 写真のいいねの数を取得する
+// GET /api/photos/:id/likes
+export async function GET(request: Request, params: { params: { id: string } }) {
+  const { id } = params.params;
+  const jwtToken = cookies().get("jwt");
+  const userToken = cookies().get("user");
+
+  if (!jwtToken || !userToken) {
+    return new Response(null, { status: 401 });
+  }
+
+  const response = await fetch(
+    `http://localhost:1337/api/likes?pagination[withCount]=true&pagination[pageSize]=1&filters[photo][$eq]=${id}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken.value}`,
+      },
+    }
+  );
+  const responseData = await response.json();
+
+  const data = {
+    data: {
+      total: responseData.meta.pagination.total,
+    },
+  };
+  return NextResponse.json(data, { status: 200 });
+}
+
+// 写真にいいねをする
+// POST /api/photos/:id/likes
+export async function POST(request: Request, params: { params: { id: string } }) {
+  const { id } = params.params;
+  const jwtToken = cookies().get("jwt");
+  const userToken = cookies().get("user");
+
+  if (!jwtToken || !userToken) {
+    return new Response(null, { status: 401 });
+  }
+
+  const res = await fetch(
+    `http://localhost:1337/api/likes?pagination[withCount]=true&pagination[pageSize]=1&filters[photo][$eq]=${id}&filters[user][$eq]=${userToken.value}`,
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwtToken.value}`,
+      },
+    }
+  );
+  const resData = await res.json();
+  // いいねの数が１の場合は既に登録されているのでエラーを返す
+  if (resData.data.length === 1) {
+    return NextResponse.json(null, { status: 400 });
+  }
+
+  const response = await fetch(`http://localhost:1337/api/likes`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${jwtToken.value}`,
+    },
+    body: JSON.stringify({
+      data: {
+        photo: id,
+        user: Number(userToken.value),
+      },
+    }),
+  });
+  const { data } = await response.json();
+
+  return NextResponse.json({ data: { id: data.id } }, { status: response.status });
+}

--- a/frontend/src/components/LikeButton.tsx
+++ b/frontend/src/components/LikeButton.tsx
@@ -1,0 +1,93 @@
+"use client";
+import { HeartIcon } from "lucide-react";
+import { FC, useEffect, useState } from "react";
+import { Button } from "./ui/button";
+
+type LikeData = {
+  id: number;
+  liked: boolean;
+  count: number;
+};
+
+type Props = {
+  photoId: number;
+};
+
+const LikeButton: FC<Props> = ({ photoId }) => {
+  const [likeData, setLikeData] = useState<LikeData>({ id: 0, liked: false, count: 0 });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // 自身のいいねを取得する
+    (async () => {
+      const meResponse = await fetch(`http://localhost:3000/api/photos/${photoId}/likes/me`);
+      if (meResponse.status === 200) {
+        const { data } = await meResponse.json();
+        if (data.length === 1) {
+          setLikeData((prev) => ({ ...prev, liked: true, id: data[0].id }));
+        }
+      }
+
+      const totalResponse = await fetch(`http://localhost:3000/api/photos/${photoId}/likes`);
+      if (totalResponse.status === 200) {
+        const { data } = await totalResponse.json();
+        setLikeData((prev) => ({ ...prev, count: data.total }));
+      }
+
+      setLoading(false);
+    })();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  const handleLike = async () => {
+    if (likeData.id !== 0) {
+      return;
+    }
+    const response = await fetch(`http://localhost:3000/api/photos/${photoId}/likes`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (response.status === 200) {
+      const { data } = await response.json();
+      setLikeData((prev) => ({ liked: true, id: data.id, count: prev.count + 1 }));
+    }
+  };
+
+  const handleUnlike = async () => {
+    if (likeData.id === 0) {
+      return;
+    }
+    const response = await fetch(`http://localhost:3000/api/likes/${likeData.id}`, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (response.status === 200) {
+      setLikeData((prev) => ({ ...prev, liked: false, id: 0 }));
+    }
+  };
+
+  return (
+    <>
+      {likeData.liked ? (
+        <Button variant="ghost" onClick={handleUnlike} size={"sm"}>
+          <HeartIcon size={24} className="fill-pink-500 text-pink-500" />
+          <span>{likeData.count}</span>
+        </Button>
+      ) : (
+        <Button variant="ghost" onClick={handleLike} size={"sm"}>
+          <HeartIcon size={24} />
+          <span>{likeData.count}</span>
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default LikeButton;


### PR DESCRIPTION
- バックエンドのstrapiにlikeテーブルを作成しました
- いいね関連のWebAPI(エンドポイント)を４つ作成しました
  - 写真の自身のいいねの有無を取得する
  - 写真のいいねの数を取得する
  - 写真にいいねをする
  - 写真のいいねを解除する
- 投稿写真詳細ページにいいねを実装しました

いいね関連の処理で、ユーザ認証が必要な処理はNext.jsのWebAPIを通さなければならないフローにしました。